### PR TITLE
[WIP] Removed dependency on deprecated matplotlib API (but broke plot display)

### DIFF
--- a/Imports/util_tk.py
+++ b/Imports/util_tk.py
@@ -47,15 +47,19 @@ try:
     import Tkinter as tk
     import ttk
     import tkFont
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg as FigureCanvasTk
+    from matplotlib.backends.backend_tkagg import NavigationToolbar2TkAgg as NavigationToolbar2Tk
+
 except Exception:
     # Python 3.x
     import tkinter as tk
     from tkinter import ttk
     import tkinter.font as tkFont
+    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_tkagg import FigureCanvasTk
+    from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
+
 import numpy as np
-from matplotlib.figure import Figure
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from matplotlib.backends.backend_tkagg import NavigationToolbar2TkAgg
 
 
 #-----------------------------------------------------------------------------#
@@ -738,8 +742,8 @@ class SingleFigFrame(ttk.Frame):
 
         # Create the blank figure canvas and grid its tk canvas
         self.fig = Figure(figsize=(4.5, 4.0))
-        self.figCanvas = FigureCanvasTkAgg(self.fig, master=self)
-        self.figCanvas.show()
+        self.figCanvas = FigureCanvasTk(self.fig, master=self)
+        self.figCanvas.draw()
         self.canvas = self.figCanvas.get_tk_widget()
         self.canvas.grid(column=0, row=0, padx=0, pady=0, sticky="NSEW")
         self.columnconfigure(0, weight=1)
@@ -752,7 +756,7 @@ class SingleFigFrame(ttk.Frame):
         return self.ax
 
     def show(self):
-        self.figCanvas.show()
+        self.figCanvas.draw()
 
     
 #-----------------------------------------------------------------------------#

--- a/vriTk.py
+++ b/vriTk.py
@@ -87,6 +87,20 @@
 
 import os
 import sys
+
+
+
+
+
+
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+from matplotlib.colors import LogNorm
+from matplotlib.ticker import MaxNLocator
+
+
 try:               # Python 2.7x
     import Tkinter as tk
     import ttk
@@ -95,6 +109,9 @@ try:               # Python 2.7x
     import tkFileDialog
     import tkSimpleDialog
     from ScrolledText import ScrolledText as tkScrolledText
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg as FigureCanvasTk
+    from matplotlib.backends.backend_tkagg import NavigationToolbar2TkAgg as NavigationToolbar2Tk
+
 except Exception:  # Python 3.x
     import tkinter as tk
     from tkinter import ttk
@@ -103,16 +120,11 @@ except Exception:  # Python 3.x
     import tkinter.filedialog as tkFileDialog
     import tkinter.simpledialog as tkSimpleDialog
     from tkinter.scrolledtext import ScrolledText as tkScrolledText
+    from matplotlib.backends.backend_tkagg import FigureCanvasTk
+    from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
 
-import numpy as np
-import matplotlib as mpl
+
 mpl.use("TkAgg")
-import matplotlib.pyplot as plt
-from matplotlib.figure import Figure
-from matplotlib.colors import LogNorm
-from matplotlib.ticker import MaxNLocator
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from matplotlib.backends.backend_tkagg import NavigationToolbar2TkAgg
 
 # Webcam library
 try:
@@ -124,7 +136,7 @@ except ImportError:
 # Disable cv2 use on Mac OS because of buggy implementation
 if sys.platform=="darwin":
     hasCV2 = False
-    
+
 from Imports.util_tk import *
 from Imports.vriCalc import *
 
@@ -285,7 +297,7 @@ class App(ttk.Frame):
         
         self.figWin = tk.Toplevel(self, background=self.bgColour)
         self.figWin.title(title)
-        figCanvas = FigureCanvasTkAgg(fig, master=self.figWin)
+        figCanvas = FigureCanvasTk(fig, master=self.figWin)
         loneCan = figCanvas.get_tk_widget()
         loneCan.configure(highlightthickness=0)
         loneCan.configure(background=self.bgColour)
@@ -1252,7 +1264,7 @@ class PlotFrame(ttk.Frame):
         
         # Create the blank figure canvas and grid its tk canvas
         self.fig = Figure(figsize=(13.0, 8.0), facecolor=bgColour)
-        self.figCanvas = FigureCanvasTkAgg(self.fig, master=self)
+        self.figCanvas = FigureCanvasTk(self.fig, master=self)
         self.canvas = self.figCanvas.get_tk_widget()
         self.canvas.configure(highlightthickness=0)
         self.canvas.configure(background=bgColour)
@@ -1434,7 +1446,7 @@ class PlotFrame(ttk.Frame):
         self.fig.subplots_adjust(left=0.07, right=0.97, top=0.95, bottom=0.07,
                                  wspace=0.27, hspace=0.24)
         self.toolbar.update()
-        self.figCanvas.show()
+        self.figCanvas.draw()
 
     def clear_by_state(self, stateDict):
         """Use a dictionary to clear downstream plots based on state."""
@@ -1490,7 +1502,7 @@ class PlotFrame(ttk.Frame):
         self.show()
 
 #-----------------------------------------------------------------------------#
-class MPLnavToolbar(NavigationToolbar2TkAgg):
+class MPLnavToolbar(NavigationToolbar2Tk):
     """Subclass the MPL navigation toolbar to disable the coord readout."""
     
     def set_message(self, msg):


### PR DESCRIPTION
Hello there,

## Introduction
Newer versions of matplotlib(>=3.0.0) prevented the program from running due to the calls to deprecated methods of the matplotlib tkagg backend API (see issue #4). I replaced the imports and api calls with the alternatives suggested in the  [matplotlib documentation](https://matplotlib.org/3.1.1/api/prev_api_changes/api_changes_3.0.0.html).

## Results
Now the program does start BUT plots won' t appear on the plot window. This is, instead of showing empty canvases (matplotlib figures) on top of the window, it shows only the empty window, like in the picture. Even if I run tasks such as calculate and plot UV coverage, the plots won' t appear.

### Empty Tk Frame with matplotlib 3.1.1
![Empty Tk Frame with matplotlib 3.1.1](https://user-images.githubusercontent.com/20826521/64479971-31f14480-d18d-11e9-99f4-ac9dbdfe04d2.png)

If I run the program with python2 and an older version of matplotlib I get the expected outcome. And 
when I prepare the simulation, the plots actually appear on this window.
### Empty Tk Frame with python2 + matplotlib 2.2.4
![Empty Tk Frame with python2 + matplotlib 2.2.4](https://user-images.githubusercontent.com/20826521/64479989-91e7eb00-d18d-11e9-88a3-c9d1ac76983a.png)

### Testing
It would be nice if someone can test these changes in their machines. The steps to reproduce the bug are rather simple:
1. Clone the matplotlib3 branch
2. Execute `python vriTk.py` with a python 3 interpreter. 

## TODO:
- Inspect the `__init__` method of the `PlotFrame` class
- Look for more Python3-migration related bugs 

I guess the fix shouldn't be that hard, but I didn' t have enough time to do proper debugging :disappointed:.

Regards,
Manuel